### PR TITLE
Removing Configuration Reference

### DIFF
--- a/featuremanagement/_featuremanagerbase.py
+++ b/featuremanagement/_featuremanagerbase.py
@@ -211,10 +211,7 @@ class FeatureManagerBase(ABC):
             return None
         for variant_reference in feature_flag.variants:
             if variant_reference.name == variant_name:
-                configuration = variant_reference.configuration_value
-                if not configuration and variant_reference.configuration_reference:
-                    configuration = self._configuration.get(variant_reference.configuration_reference)
-                return Variant(variant_reference.name, configuration)
+                return Variant(variant_reference.name, variant_reference.configuration_value)
         return None
 
     def _build_targeting_context(self, args: Tuple[Any]) -> TargetingContext:

--- a/featuremanagement/_models/_constants.py
+++ b/featuremanagement/_models/_constants.py
@@ -30,5 +30,4 @@ SEED = "seed"
 # Variant Reference
 VARIANT_REFERENCE_NAME = "name"
 CONFIGURATION_VALUE = "configuration_value"
-CONFIGURATION_REFERENCE = "configuration_reference"
 STATUS_OVERRIDE = "status_override"

--- a/featuremanagement/_models/_variant_reference.py
+++ b/featuremanagement/_models/_variant_reference.py
@@ -6,7 +6,7 @@
 from dataclasses import dataclass
 from typing import Optional, Mapping, Any
 from typing_extensions import Self
-from ._constants import VARIANT_REFERENCE_NAME, CONFIGURATION_VALUE, CONFIGURATION_REFERENCE, STATUS_OVERRIDE
+from ._constants import VARIANT_REFERENCE_NAME, CONFIGURATION_VALUE, STATUS_OVERRIDE
 
 
 @dataclass
@@ -18,7 +18,6 @@ class VariantReference:
     def __init__(self) -> None:
         self._name = None
         self._configuration_value = None
-        self._configuration_reference = None
         self._status_override = None
 
     @classmethod
@@ -33,7 +32,6 @@ class VariantReference:
         variant_reference = cls()
         variant_reference._name = json.get(VARIANT_REFERENCE_NAME)
         variant_reference._configuration_value = json.get(CONFIGURATION_VALUE)
-        variant_reference._configuration_reference = json.get(CONFIGURATION_REFERENCE)
         variant_reference._status_override = json.get(STATUS_OVERRIDE, None)
         return variant_reference
 
@@ -56,16 +54,6 @@ class VariantReference:
         :rtype: str
         """
         return self._configuration_value
-
-    @property
-    def configuration_reference(self) -> Optional[str]:
-        """
-        Get the configuration reference for the variant.
-
-        :return: Configuration reference for the variant.
-        :rtype: str
-        """
-        return self._configuration_reference
 
     @property
     def status_override(self) -> Optional[str]:

--- a/samples/formatted_feature_flags.json
+++ b/samples/formatted_feature_flags.json
@@ -218,7 +218,6 @@
                     },
                     {
                         "name": "False_Override",
-                        "configuration_reference": "false-override",
                         "status_override": "True"
                     }
                 ]


### PR DESCRIPTION
# Description

Removes `configuration_reference` as it's been removed from the schema.

# Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/microsoft/FeatureManagement-Python/blob/main/CONTRIBUTING.md).**
- [ ] Pull request includes test coverage for the included changes.

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
