### PR TITLE
Remove Dependencies

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,10 +19,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r dev_requirements.txt
         pip install .
-    - name: Analysing the code/samples with pylint
+    - name: Analysing the code with pylint
       run: |
         pylint featuremanagement
-        pylint --disable=missing-function-docstring,missing-class-docstring samples tests
     - uses: psf/black@stable
     - name: Run mypy
       run: |
@@ -33,3 +32,6 @@ jobs:
       run: |
         pip install -r requirements.txt
         pytest tests --doctest-modules --cov-report=xml --cov-report=html
+    - name: Analysing the samples with pylint
+      run: |
+        pylint --disable=missing-function-docstring,missing-class-docstring samples tests

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,11 +24,12 @@ jobs:
         pylint featuremanagement
         pylint --disable=missing-function-docstring,missing-class-docstring samples tests
     - uses: psf/black@stable
-    - name: Test with pytest
-      run: |
-        pytest tests --doctest-modules --cov-report=xml --cov-report=html
     - name: Run mypy
       run: |
         mypy featuremanagement
     - name: cspell-action
       uses: streetsidesoftware/cspell-action@v6.8.0
+    - name: Test with pytest
+      run: |
+        pip install -r requirements.txt
+        pytest tests --doctest-modules --cov-report=xml --cov-report=html

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
       uses: streetsidesoftware/cspell-action@v6.8.0
     - name: Test with pytest
       run: |
-        pip install -r requirements.txt
+        pip install -r tests/requirements.txt
         pytest tests --doctest-modules --cov-report=xml --cov-report=html
     - name: Analysing the samples with pylint
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,4 +34,5 @@ jobs:
         pytest tests --doctest-modules --cov-report=xml --cov-report=html
     - name: Analysing the samples with pylint
       run: |
+        pip install -r samples/requirements.txt
         pylint --disable=missing-function-docstring,missing-class-docstring samples tests

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,6 +8,3 @@ sphinx
 sphinx_rtd_theme
 sphinx-toolbox
 myst_parser
-azure-appconfiguration-provider
-azure-monitor-opentelemetry
-azure-monitor-events-extension

--- a/featuremanagement/_featurefilters.py
+++ b/featuremanagement/_featurefilters.py
@@ -4,8 +4,7 @@
 # license information.
 # -------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Mapping, Callable, Any, Optional
-from typing_extensions import Self
+from typing import Mapping, Callable, Any, Optional, Self
 
 
 class FeatureFilter(ABC):

--- a/featuremanagement/_featurefilters.py
+++ b/featuremanagement/_featurefilters.py
@@ -4,7 +4,7 @@
 # license information.
 # -------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Mapping, Callable, Any, Optional, Self
+from typing import Mapping, Callable, Any, Optional
 
 
 class FeatureFilter(ABC):
@@ -44,7 +44,7 @@ class FeatureFilter(ABC):
         :rtype: Callable
         """
 
-        def wrapper(cls: Self) -> Any:
+        def wrapper(cls) -> Any: # type: ignore
             cls._alias = alias  # pylint: disable=protected-access
             return cls
 

--- a/featuremanagement/_featurefilters.py
+++ b/featuremanagement/_featurefilters.py
@@ -44,7 +44,7 @@ class FeatureFilter(ABC):
         :rtype: Callable
         """
 
-        def wrapper(cls) -> Any: # type: ignore
+        def wrapper(cls: "FeatureFilter") -> Any:
             cls._alias = alias  # pylint: disable=protected-access
             return cls
 

--- a/featuremanagement/aio/_featurefilters.py
+++ b/featuremanagement/aio/_featurefilters.py
@@ -4,8 +4,7 @@
 # license information.
 # -------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Mapping, Callable, Any, Optional
-from typing_extensions import Self
+from typing import Mapping, Callable, Any, Optional, Self
 
 
 class FeatureFilter(ABC):

--- a/featuremanagement/aio/_featurefilters.py
+++ b/featuremanagement/aio/_featurefilters.py
@@ -4,7 +4,7 @@
 # license information.
 # -------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Mapping, Callable, Any, Optional, Self
+from typing import Mapping, Callable, Any, Optional
 
 
 class FeatureFilter(ABC):
@@ -44,7 +44,7 @@ class FeatureFilter(ABC):
         :rtype: Callable
         """
 
-        def wrapper(cls: Self) -> Any:
+        def wrapper(cls) -> Any: # type: ignore
             cls._alias = alias  # pylint: disable=protected-access
             return cls
 

--- a/featuremanagement/aio/_featurefilters.py
+++ b/featuremanagement/aio/_featurefilters.py
@@ -44,7 +44,7 @@ class FeatureFilter(ABC):
         :rtype: Callable
         """
 
-        def wrapper(cls) -> Any: # type: ignore
+        def wrapper(cls: "FeatureFilter") -> Any:
             cls._alias = alias  # pylint: disable=protected-access
             return cls
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ max-returns = 7
 disable = ["missing-module-docstring", "duplicate-code"]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "pylint", "pytest-asyncio", "mypy", "black"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/samples/requirements.txt
+++ b/samples/requirements.txt
@@ -1,0 +1,4 @@
+featuremanagement
+azure-appconfiguration-provider
+azure-monitor-opentelemetry
+azure-monitor-events-extension

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+azure-monitor-opentelemetry
+azure-monitor-events-extension


### PR DESCRIPTION
# Description

While adding typing checking a dependency was added by mistake, `typing_extentions`. I've updated the code to not use this dependency. I've also reworked the build setup so that this shouldn't have unexpected dependencies in the future.

This library is a dependency of the provider library, which we have listed as a dev dependency, so it is only noticed if not setting up from dev dependencies and not using the provider.