### PR TITLE
Removing typing extension

### DIFF
--- a/featuremanagement/_models/_allocation.py
+++ b/featuremanagement/_models/_allocation.py
@@ -5,7 +5,6 @@
 # -------------------------------------------------------------------------
 from typing import cast, List, Optional, Mapping, Dict, Any, Union
 from dataclasses import dataclass
-from typing_extensions import Self
 from ._constants import DEFAULT_WHEN_ENABLED, DEFAULT_WHEN_DISABLED, USER, GROUP, PERCENTILE, SEED
 
 
@@ -40,7 +39,7 @@ class PercentileAllocation:
         self._percentile_to: Optional[int] = None
 
     @classmethod
-    def convert_from_json(cls, json: Mapping[str, Union[str, int]]) -> Self:
+    def convert_from_json(cls, json: Mapping[str, Union[str, int]]) -> "PercentileAllocation":
         """
         Convert a JSON object to PercentileAllocation.
 
@@ -113,7 +112,7 @@ class Allocation:
         self._seed = "allocation\n" + feature_name
 
     @classmethod
-    def convert_from_json(cls, json: Dict[str, Any], feature_name: str) -> Optional[Self]:
+    def convert_from_json(cls, json: Dict[str, Any], feature_name: str) -> Optional["Allocation"]:
         """
         Convert a JSON object to Allocation.
 

--- a/featuremanagement/_models/_feature_conditions.py
+++ b/featuremanagement/_models/_feature_conditions.py
@@ -5,7 +5,6 @@
 # -------------------------------------------------------------------------
 from collections.abc import Mapping
 from typing import Any, Dict, List
-from typing_extensions import Self
 from ._constants import (
     FEATURE_FLAG_CLIENT_FILTERS,
     FEATURE_FILTER_NAME,
@@ -25,7 +24,7 @@ class FeatureConditions:
         self._client_filters: List[Dict[str, Any]] = []
 
     @classmethod
-    def convert_from_json(cls, feature_name: str, json_value: str) -> Self:
+    def convert_from_json(cls, feature_name: str, json_value: str) -> "FeatureConditions":
         """
         Convert a JSON object to FeatureConditions.
 

--- a/featuremanagement/_models/_feature_flag.py
+++ b/featuremanagement/_models/_feature_flag.py
@@ -4,7 +4,6 @@
 # license information.
 # -------------------------------------------------------------------------
 from typing import cast, List, Union, Optional, Mapping, Any
-from typing_extensions import Self
 from ._feature_conditions import FeatureConditions
 from ._allocation import Allocation
 from ._variant_reference import VariantReference
@@ -32,7 +31,7 @@ class FeatureFlag:
         self._telemetry: Telemetry = Telemetry()
 
     @classmethod
-    def convert_from_json(cls, json_value: Mapping[str, Any]) -> Self:
+    def convert_from_json(cls, json_value: Mapping[str, Any]) -> "FeatureFlag":
         """
         Convert a JSON object to FeatureFlag.
 

--- a/featuremanagement/_models/_variant_reference.py
+++ b/featuremanagement/_models/_variant_reference.py
@@ -5,7 +5,6 @@
 # -------------------------------------------------------------------------
 from dataclasses import dataclass
 from typing import Optional, Mapping, Any
-from typing_extensions import Self
 from ._constants import VARIANT_REFERENCE_NAME, CONFIGURATION_VALUE, STATUS_OVERRIDE
 
 
@@ -21,7 +20,7 @@ class VariantReference:
         self._status_override = None
 
     @classmethod
-    def convert_from_json(cls, json: Mapping[str, Any]) -> Self:
+    def convert_from_json(cls, json: Mapping[str, Any]) -> "VariantReference":
         """
         Convert a JSON object to VariantReference.
 


### PR DESCRIPTION
# Description

`typing_extension` would add a new dependency, and we don't really need it. Updating to work without it.

Note: currently this dependency isn't included in our build so our library breaks if run if not installed.
Note2: This dependency is a dependency of `azure-monitor-opentelemetry` so we currently don't have a way to test it without it installed.