### PR TITLE
Assignment Fix

### DIFF
--- a/featuremanagement/_featuremanagerbase.py
+++ b/featuremanagement/_featuremanagerbase.py
@@ -168,13 +168,13 @@ class FeatureManagerBase(ABC):
                 if targeting_context.user_id in user_allocation.users:
                     evaluation_event.reason = VariantAssignmentReason.USER
                     variant_name = user_allocation.variant
-        elif feature.allocation.group and len(targeting_context.groups) > 0:
+        if not variant_name and feature.allocation.group and len(targeting_context.groups) > 0:
             for group_allocation in feature.allocation.group:
                 for group in targeting_context.groups:
                     if group in group_allocation.groups:
                         evaluation_event.reason = VariantAssignmentReason.GROUP
                         variant_name = group_allocation.variant
-        elif feature.allocation.percentile:
+        if not variant_name and feature.allocation.percentile:
             context_id = targeting_context.user_id + "\n" + feature.allocation.seed
             box: float = self._is_targeted(context_id)
             for percentile_allocation in feature.allocation.percentile:

--- a/tests/test_feature_variants.py
+++ b/tests/test_feature_variants.py
@@ -148,9 +148,7 @@ class TestFeatureVariants:
         assert not feature_manager.is_enabled("Alpha", TargetingContext(user_id="NotAdam", groups=["Group1"]))
         assert feature_manager.get_variant("Alpha", TargetingContext(user_id="NotAdam", groups=["Group1"])).name == "On"
         assert not feature_manager.is_enabled("Alpha", TargetingContext(user_id="NotAdam", groups=["Group1"]))
-        assert (
-            feature_manager.get_variant("Alpha", TargetingContext(groups=["Group2"])).name == "Off"
-        )
+        assert feature_manager.get_variant("Alpha", TargetingContext(groups=["Group2"])).name == "Off"
         assert feature_manager.is_enabled("Alpha", TargetingContext(user_id="NotCharlie", groups=["Group3"]))
         assert feature_manager.get_variant("Alpha", TargetingContext(user_id="NotCharlie", groups=["Group3"])) is None
 


### PR DESCRIPTION
# Description

In the current version `elif` is used, resulting in any user allocation skipping group/percentile assignment.