### PR TITLE
Disable pylint warning for unused argument

### DIFF
--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -127,7 +127,7 @@ class TargetingSpanProcessor(SpanProcessor):
             "targeting_context_accessor", None
         )
 
-    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None: # pylint: disable=unused-argument
         """
         Attaches the targeting ID to the span and baggage when a new span is started.
 

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -127,7 +127,7 @@ class TargetingSpanProcessor(SpanProcessor):
             "targeting_context_accessor", None
         )
 
-    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None: # pylint: disable=unused-argument
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:  # pylint: disable=unused-argument
         """
         Attaches the targeting ID to the span and baggage when a new span is started.
 

--- a/samples/feature_variant_sample_with_targeting_accessor.py
+++ b/samples/feature_variant_sample_with_targeting_accessor.py
@@ -16,11 +16,11 @@ script_directory = os.path.dirname(os.path.abspath(sys.argv[0]))
 with open(script_directory + "/formatted_feature_flags.json", "r", encoding="utf-8") as f:
     feature_flags = json.load(f)
 
-USER_ID = "Adam"
+user_id = "Adam"
 
 
 def my_targeting_accessor() -> TargetingContext:
-    return TargetingContext(user_id=USER_ID)
+    return TargetingContext(user_id=user_id)
 
 
 feature_manager = FeatureManager(
@@ -30,7 +30,7 @@ feature_manager = FeatureManager(
 print(feature_manager.is_enabled("TestVariants"))
 print(feature_manager.get_variant("TestVariants").configuration)
 
-USER_ID = "Ellie"
+user_id = "Ellie"
 
 print(feature_manager.is_enabled("TestVariants"))
 print(feature_manager.get_variant("TestVariants").configuration)

--- a/samples/feature_variant_sample_with_targeting_accessor.py
+++ b/samples/feature_variant_sample_with_targeting_accessor.py
@@ -16,6 +16,7 @@ script_directory = os.path.dirname(os.path.abspath(sys.argv[0]))
 with open(script_directory + "/formatted_feature_flags.json", "r", encoding="utf-8") as f:
     feature_flags = json.load(f)
 
+# pylint: disable=invalid-name
 user_id = "Adam"
 
 


### PR DESCRIPTION
Add pylint disable comment for unused argument in on_start method.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/FeatureManagement-Python/blob/main/CONTRIBUTING.md).**
- [ ] Pull request includes test coverage for the included changes.

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
