### PR TITLE
Update telemetry event dependency to OpenTelemetry LoggingHandler

### DIFF
--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -80,11 +80,16 @@ def track_event(event_name: str, user: str, event_properties: Optional[Dict[str,
         event_properties[TARGETING_ID] = user
 
     # Azure Monitor exporter maps this attribute to customEvent telemetry name.
-    custom_event_attributes = {
-        **event_properties,
-        "microsoft.custom_event.name": event_name,
-    }
-    _event_logger.info(event_name, extra=custom_event_attributes)
+    custom_event_attributes = {**event_properties, "microsoft.custom_event.name": event_name}
+
+    # logging raises KeyError if an `extra` key overwrites a built-in LogRecord attribute (e.g. "name", "message").
+    reserved = logging.makeLogRecord({}).__dict__
+    safe_attributes: Dict[str, Optional[str]] = {}
+    for key, value in custom_event_attributes.items():
+        safe_key = key if key not in reserved else f"telemetry.{key}"
+        safe_attributes[safe_key] = value
+
+    _event_logger.info(event_name, extra=safe_attributes)
 
 
 def publish_telemetry(evaluation_event: EvaluationEvent) -> None:

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -7,6 +7,7 @@
 
 import logging
 import inspect
+from logging import INFO
 from typing import Any, Callable, Dict, Optional
 from .._models import VariantAssignmentReason, EvaluationEvent, TargetingContext
 
@@ -17,7 +18,6 @@ _event_logger = logging.getLogger(__name__ + ".events")
 _event_logger.propagate = False
 
 try:
-    from logging import INFO
     from opentelemetry.sdk._logs import LoggingHandler
     from opentelemetry.sdk.trace import SpanProcessor
 
@@ -28,20 +28,17 @@ except ImportError:
     SpanProcessor = object  # type: ignore
 
 
-_EVENTS_LOGGER_INITIALIZED: list[bool] = []
+_EVENTS_LOGGER_INITIALIZED: bool = False
 
 
 def _initialize_event_logger() -> None:
+    global _EVENTS_LOGGER_INITIALIZED  # pylint: disable=global-statement
     if _EVENTS_LOGGER_INITIALIZED:
-        return
-
-    if not HAS_OPENTELEMETRY_LOGGING:
-        logger.warning("OpenTelemetry logging handler is not installed. Telemetry will not be sent.")
         return
 
     _event_logger.addHandler(LoggingHandler())
     _event_logger.setLevel(INFO)
-    _EVENTS_LOGGER_INITIALIZED.append(True)
+    _EVENTS_LOGGER_INITIALIZED = True
 
 
 FEATURE_NAME = "FeatureName"
@@ -54,6 +51,7 @@ DEFAULT_WHEN_ENABLED = "DefaultWhenEnabled"
 VERSION = "Version"
 VARIANT_ASSIGNMENT_PERCENTAGE = "VariantAssignmentPercentage"
 MICROSOFT_TARGETING_ID = "Microsoft.TargetingId"
+CUSTOM_EVENT_NAME = "microsoft.custom_event.name"
 
 EVENT_NAME = "FeatureEvaluation"
 
@@ -79,16 +77,11 @@ def track_event(event_name: str, user: str, event_properties: Optional[Dict[str,
         event_properties[TARGETING_ID] = user
 
     # Azure Monitor exporter maps this attribute to customEvent telemetry name.
-    custom_event_attributes = {**event_properties, "microsoft.custom_event.name": event_name}
-
-    # logging raises KeyError if an `extra` key overwrites a built-in LogRecord attribute (e.g. "name", "message").
-    reserved = logging.makeLogRecord({}).__dict__
-    safe_attributes: Dict[str, Optional[str]] = {}
-    for key, value in custom_event_attributes.items():
-        safe_key = key if key not in reserved else f"telemetry.{key}"
-        safe_attributes[safe_key] = value
-
-    _event_logger.info(event_name, extra=safe_attributes)
+    custom_event_attributes = {
+        **event_properties,
+        CUSTOM_EVENT_NAME: event_name,
+    }
+    _event_logger.info(event_name, extra=custom_event_attributes)
 
 
 def publish_telemetry(evaluation_event: EvaluationEvent) -> None:
@@ -166,7 +159,7 @@ class TargetingSpanProcessor(SpanProcessor):
         :param parent_context: The parent context of the span.
         """
         if not HAS_OPENTELEMETRY_LOGGING:
-            logger.warning("OpenTelemetry logging handler is not installed.")
+            logger.info("OpenTelemetry logging handler is not installed.")
             return
         if self._targeting_context_accessor and callable(self._targeting_context_accessor):
             if inspect.iscoroutinefunction(self._targeting_context_accessor):

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -30,6 +30,21 @@ except ImportError:
     Span = object  # type: ignore
     Context = object  # type: ignore
 
+FEATURE_NAME = "FeatureName"
+ENABLED = "Enabled"
+TARGETING_ID = "TargetingId"
+VARIANT = "Variant"
+REASON = "VariantAssignmentReason"
+
+DEFAULT_WHEN_ENABLED = "DefaultWhenEnabled"
+VERSION = "Version"
+VARIANT_ASSIGNMENT_PERCENTAGE = "VariantAssignmentPercentage"
+MICROSOFT_TARGETING_ID = "Microsoft.TargetingId"
+AZURE_MONITOR_EVENT_NAME = "microsoft.custom_event.name"
+
+EVENT_NAME = "FeatureEvaluation"
+
+EVALUATION_EVENT_VERSION = "1.0.0"
 
 _EVENTS_LOGGER_INITIALIZED: bool = False
 
@@ -42,23 +57,6 @@ def _initialize_event_logger() -> None:
     _event_logger.addHandler(LoggingHandler())
     _event_logger.setLevel(INFO)
     _EVENTS_LOGGER_INITIALIZED = True
-
-
-FEATURE_NAME = "FeatureName"
-ENABLED = "Enabled"
-TARGETING_ID = "TargetingId"
-VARIANT = "Variant"
-REASON = "VariantAssignmentReason"
-
-DEFAULT_WHEN_ENABLED = "DefaultWhenEnabled"
-VERSION = "Version"
-VARIANT_ASSIGNMENT_PERCENTAGE = "VariantAssignmentPercentage"
-MICROSOFT_TARGETING_ID = "Microsoft.TargetingId"
-CUSTOM_EVENT_NAME = "microsoft.custom_event.name"
-
-EVENT_NAME = "FeatureEvaluation"
-
-EVALUATION_EVENT_VERSION = "1.0.0"
 
 
 def track_event(event_name: str, user: str, event_properties: Optional[Dict[str, Optional[str]]] = None) -> None:
@@ -82,7 +80,7 @@ def track_event(event_name: str, user: str, event_properties: Optional[Dict[str,
     # Azure Monitor exporter maps this attribute to customEvent telemetry name.
     custom_event_attributes = {
         **event_properties,
-        CUSTOM_EVENT_NAME: event_name,
+        AZURE_MONITOR_EVENT_NAME: event_name,
     }
     _event_logger.info(event_name, extra=custom_event_attributes)
 

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -28,11 +28,10 @@ except ImportError:
     SpanProcessor = object  # type: ignore
 
 
-_events_logger_initialized = False
+_EVENTS_LOGGER_INITIALIZED: list[bool] = []
 
 def _initialize_event_logger() -> None:
-    global _events_logger_initialized
-    if _events_logger_initialized:
+    if _EVENTS_LOGGER_INITIALIZED:
         return
 
     if not HAS_OPENTELEMETRY_LOGGING:
@@ -43,7 +42,8 @@ def _initialize_event_logger() -> None:
 
     _event_logger.addHandler(LoggingHandler())
     _event_logger.setLevel(INFO)
-    _events_logger_initialized = True
+    _EVENTS_LOGGER_INITIALIZED.append(True)
+
 
 FEATURE_NAME = "FeatureName"
 ENABLED = "Enabled"
@@ -80,11 +80,16 @@ def track_event(event_name: str, user: str, event_properties: Optional[Dict[str,
         event_properties[TARGETING_ID] = user
 
     # Azure Monitor exporter maps this attribute to customEvent telemetry name.
-    custom_event_attributes = {
-        **event_properties,
-        "microsoft.custom_event.name": event_name,
-    }
-    _event_logger.info(event_name, extra=custom_event_attributes)
+    custom_event_attributes = {**event_properties, "microsoft.custom_event.name": event_name}
+
+    # logging raises KeyError if an `extra` key overwrites a built-in LogRecord attribute (e.g. "name", "message").
+    reserved = logging.makeLogRecord({}).__dict__
+    safe_attributes: Dict[str, Optional[str]] = {}
+    for key, value in custom_event_attributes.items():
+        safe_key = key if key not in reserved else f"telemetry.{key}"
+        safe_attributes[safe_key] = value
+
+    _event_logger.info(event_name, extra=safe_attributes)
 
 
 def publish_telemetry(evaluation_event: EvaluationEvent) -> None:

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -12,20 +12,38 @@ from .._models import VariantAssignmentReason, EvaluationEvent, TargetingContext
 
 logger = logging.getLogger(__name__)
 
-try:
-    from azure.monitor.events.extension import track_event as azure_monitor_track_event  # type: ignore
-    from opentelemetry.context.context import Context
-    from opentelemetry.sdk.trace import Span, SpanProcessor
+# Set up a separate logger for feature-evaluation telemetry events to avoid propagating to the root logger
+_event_logger = logging.getLogger(__name__ + ".events")
+_event_logger.propagate = False
 
-    HAS_AZURE_MONITOR_EVENTS_EXTENSION = True
+try:
+    from logging import INFO
+    from opentelemetry.instrumentation.logging.handler import LoggingHandler
+    from opentelemetry.sdk.trace import SpanProcessor
+
+    HAS_OPENTELEMETRY_LOGGING = True
 except ImportError:
-    HAS_AZURE_MONITOR_EVENTS_EXTENSION = False
-    logger.warning(
-        "azure-monitor-events-extension is not installed. Telemetry will not be sent to Application Insights."
-    )
+    HAS_OPENTELEMETRY_LOGGING = False
+    LoggingHandler = object  # type: ignore
     SpanProcessor = object  # type: ignore
-    Span = object  # type: ignore
-    Context = object  # type: ignore
+
+
+_events_logger_initialized = False
+
+def _initialize_event_logger() -> None:
+    global _events_logger_initialized
+    if _events_logger_initialized:
+        return
+
+    if not HAS_OPENTELEMETRY_LOGGING:
+        logger.warning(
+            "OpenTelemetry logging handler is not installed. Telemetry will not be sent to Application Insights."
+        )
+        return
+
+    _event_logger.addHandler(LoggingHandler())
+    _event_logger.setLevel(INFO)
+    _events_logger_initialized = True
 
 FEATURE_NAME = "FeatureName"
 ENABLED = "Enabled"
@@ -51,15 +69,22 @@ def track_event(event_name: str, user: str, event_properties: Optional[Dict[str,
     :param str user: The user ID to associate with the event.
     :param dict[str, str] event_properties: A dictionary of named string properties.
     """
-    if not HAS_AZURE_MONITOR_EVENTS_EXTENSION:
+    if not HAS_OPENTELEMETRY_LOGGING:
         return
+
+    _initialize_event_logger()
 
     event_properties = event_properties or {}
 
     if user:
         event_properties[TARGETING_ID] = user
 
-    azure_monitor_track_event(event_name, event_properties)
+    # Azure Monitor exporter maps this attribute to customEvent telemetry name.
+    custom_event_attributes = {
+        **event_properties,
+        "microsoft.custom_event.name": event_name,
+    }
+    _event_logger.info(event_name, extra=custom_event_attributes)
 
 
 def publish_telemetry(evaluation_event: EvaluationEvent) -> None:
@@ -68,7 +93,7 @@ def publish_telemetry(evaluation_event: EvaluationEvent) -> None:
 
     :param EvaluationEvent evaluation_event: The evaluation event to publish telemetry for.
     """
-    if not HAS_AZURE_MONITOR_EVENTS_EXTENSION:
+    if not HAS_OPENTELEMETRY_LOGGING:
         return
 
     feature = evaluation_event.feature
@@ -129,15 +154,15 @@ class TargetingSpanProcessor(SpanProcessor):
             "targeting_context_accessor", None
         )
 
-    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:  # pylint: disable=unused-argument
+    def on_start(self, span: Any, parent_context: Optional[Any] = None) -> None:  # pylint: disable=unused-argument
         """
         Attaches the targeting ID to the span and baggage when a new span is started.
 
         :param Span span: The span that was started.
         :param parent_context: The parent context of the span.
         """
-        if not HAS_AZURE_MONITOR_EVENTS_EXTENSION:
-            logger.warning("Azure Monitor Events Extension is not installed.")
+        if not HAS_OPENTELEMETRY_LOGGING:
+            logger.warning("OpenTelemetry logging handler is not installed.")
             return
         if self._targeting_context_accessor and callable(self._targeting_context_accessor):
             if inspect.iscoroutinefunction(self._targeting_context_accessor):

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -19,13 +19,16 @@ _event_logger.propagate = False
 
 try:
     from opentelemetry.sdk._logs import LoggingHandler
-    from opentelemetry.sdk.trace import SpanProcessor
+    from opentelemetry.context.context import Context
+    from opentelemetry.sdk.trace import Span, SpanProcessor
 
     HAS_OPENTELEMETRY_LOGGING = True
 except ImportError:
     HAS_OPENTELEMETRY_LOGGING = False
     LoggingHandler = object  # type: ignore
     SpanProcessor = object  # type: ignore
+    Span = object  # type: ignore
+    Context = object  # type: ignore
 
 
 _EVENTS_LOGGER_INITIALIZED: bool = False
@@ -151,7 +154,7 @@ class TargetingSpanProcessor(SpanProcessor):
             "targeting_context_accessor", None
         )
 
-    def on_start(self, span: Any, parent_context: Optional[Any] = None) -> None:  # pylint: disable=unused-argument
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:  # pylint: disable=unused-argument
         """
         Attaches the targeting ID to the span and baggage when a new span is started.
 

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -36,9 +36,7 @@ def _initialize_event_logger() -> None:
         return
 
     if not HAS_OPENTELEMETRY_LOGGING:
-        logger.warning(
-            "OpenTelemetry logging handler is not installed. Telemetry will not be sent."
-        )
+        logger.warning("OpenTelemetry logging handler is not installed. Telemetry will not be sent.")
         return
 
     _event_logger.addHandler(LoggingHandler())

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -37,7 +37,7 @@ def _initialize_event_logger() -> None:
 
     if not HAS_OPENTELEMETRY_LOGGING:
         logger.warning(
-            "OpenTelemetry logging handler is not installed. Telemetry will not be sent to Application Insights."
+            "OpenTelemetry logging handler is not installed. Telemetry will not be sent."
         )
         return
 

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -30,6 +30,7 @@ except ImportError:
 
 _EVENTS_LOGGER_INITIALIZED: list[bool] = []
 
+
 def _initialize_event_logger() -> None:
     if _EVENTS_LOGGER_INITIALIZED:
         return

--- a/featuremanagement/azuremonitor/_send_telemetry.py
+++ b/featuremanagement/azuremonitor/_send_telemetry.py
@@ -18,7 +18,7 @@ _event_logger.propagate = False
 
 try:
     from logging import INFO
-    from opentelemetry.instrumentation.logging.handler import LoggingHandler
+    from opentelemetry.sdk._logs import LoggingHandler
     from opentelemetry.sdk.trace import SpanProcessor
 
     HAS_OPENTELEMETRY_LOGGING = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,10 @@ Homepage = "https://github.com/microsoft/FeatureManagement-Python"
 Issues = "https://github.com/microsoft/FeatureManagement-Python/issues"
 
 [project.optional-dependencies]
-AzureMonitor = ["azure-monitor-opentelemetry < 2.0.0"]
+AzureMonitor = ["azure-monitor-opentelemetry < 2.0.0", "opentelemetry-instrumentation-logging >= 0.40b0, < 1.0.0"]
 test = [
     "azure-monitor-opentelemetry < 2.0.0",
+    "opentelemetry-instrumentation-logging >= 0.40b0, < 1.0.0",
 ]
 dev = [
     "pytest >= 7.0.0, < 10.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,9 @@ Homepage = "https://github.com/microsoft/FeatureManagement-Python"
 Issues = "https://github.com/microsoft/FeatureManagement-Python/issues"
 
 [project.optional-dependencies]
-AzureMonitor = ["azure-monitor-events-extension<2.0.0"]
+AzureMonitor = ["azure-monitor-opentelemetry < 2.0.0"]
 test = [
     "azure-monitor-opentelemetry < 2.0.0",
-    "azure-monitor-events-extension < 2.0.0",
 ]
 dev = [
     "pytest >= 7.0.0, < 10.0.0",
@@ -76,4 +75,5 @@ dev = [
     "myst_parser >= 2.0.0, < 6.0.0",
     "opentelemetry-api >= 1.20.0, < 2.0.0",
     "opentelemetry-sdk >= 1.20.0, < 2.0.0",
+    "opentelemetry-instrumentation-logging >= 0.40b0, < 1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ Homepage = "https://github.com/microsoft/FeatureManagement-Python"
 Issues = "https://github.com/microsoft/FeatureManagement-Python/issues"
 
 [project.optional-dependencies]
-AzureMonitor = ["opentelemetry-sdk >= 1.20.0, < 2.0.0"]
+AzureMonitor = ["opentelemetry-sdk~=1.20"]
 test = [
     "azure-monitor-opentelemetry < 2.0.0",
 ]
@@ -73,6 +73,6 @@ dev = [
     "sphinx_rtd_theme >= 2.0.0, < 4.0.0",
     "sphinx-toolbox >= 3.0.0, < 5.0.0",
     "myst_parser >= 2.0.0, < 6.0.0",
-    "opentelemetry-api >= 1.20.0, < 2.0.0",
-    "opentelemetry-sdk >= 1.20.0, < 2.0.0",
+    "opentelemetry-api~=1.20",
+    "opentelemetry-sdk~=1.20",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,9 @@ Homepage = "https://github.com/microsoft/FeatureManagement-Python"
 Issues = "https://github.com/microsoft/FeatureManagement-Python/issues"
 
 [project.optional-dependencies]
-AzureMonitor = ["azure-monitor-opentelemetry < 2.0.0", "opentelemetry-instrumentation-logging >= 0.40b0, < 1.0.0"]
+AzureMonitor = ["opentelemetry-sdk >= 1.20.0, < 2.0.0"]
 test = [
     "azure-monitor-opentelemetry < 2.0.0",
-    "opentelemetry-instrumentation-logging >= 0.40b0, < 1.0.0",
 ]
 dev = [
     "pytest >= 7.0.0, < 10.0.0",
@@ -76,5 +75,4 @@ dev = [
     "myst_parser >= 2.0.0, < 6.0.0",
     "opentelemetry-api >= 1.20.0, < 2.0.0",
     "opentelemetry-sdk >= 1.20.0, < 2.0.0",
-    "opentelemetry-instrumentation-logging >= 0.40b0, < 1.0.0",
 ]

--- a/samples/requirements.txt
+++ b/samples/requirements.txt
@@ -1,6 +1,5 @@
 featuremanagement
 azure-appconfiguration-provider
 azure-monitor-opentelemetry
-azure-monitor-events-extension
 quart
 azure-identity

--- a/tests/test_send_telemetry_appinsights.py
+++ b/tests/test_send_telemetry_appinsights.py
@@ -13,6 +13,10 @@ import featuremanagement.azuremonitor._send_telemetry
 from featuremanagement.azuremonitor import TargetingSpanProcessor
 
 
+def _event_properties(mock_track_event):
+    return mock_track_event.call_args.kwargs["event_properties"]
+
+
 @pytest.mark.usefixtures("caplog")
 class TestSendTelemetryAppinsights:
 
@@ -40,23 +44,45 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_DISABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.azure_monitor_track_event") as mock_track_event:
+        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
             # This is called like this so we can override the track_event function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
             mock_track_event.assert_called_once()
             assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1]["FeatureName"] == "TestFeature"
-            assert mock_track_event.call_args[0][1]["Enabled"] == "True"
-            assert mock_track_event.call_args[0][1]["TargetingId"] == "test_user"
-            assert mock_track_event.call_args[0][1]["Variant"] == "TestVariant"
-            assert mock_track_event.call_args[0][1]["ETag"] == "cmwBRcIAq1jUyKL3Kj8bvf9jtxBrFg-R-ayExStMC90"
+            assert mock_track_event.call_args[0][1] == "test_user"
+            event_properties = _event_properties(mock_track_event)
+            assert event_properties["FeatureName"] == "TestFeature"
+            assert event_properties["Enabled"] == "True"
+            assert event_properties["Variant"] == "TestVariant"
+            assert event_properties["ETag"] == "cmwBRcIAq1jUyKL3Kj8bvf9jtxBrFg-R-ayExStMC90"
             assert (
-                mock_track_event.call_args[0][1]["FeatureFlagReference"]
+                event_properties["FeatureFlagReference"]
                 == "fake-store-uri/kv/.appconfig.featureflag/TestFeature"
             )
-            assert mock_track_event.call_args[0][1]["FeatureFlagId"] == "fake-feature-flag-id"
+            assert event_properties["FeatureFlagId"] == "fake-feature-flag-id"
+
+    def test_track_event_preserves_reserved_custom_event_name(self):
+        with patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"), patch(
+            "featuremanagement.azuremonitor._send_telemetry._event_logger.info"
+        ) as mock_event_logger_info, patch(
+            "featuremanagement.azuremonitor._send_telemetry.HAS_OPENTELEMETRY_LOGGING", True
+        ):
+            featuremanagement.azuremonitor._send_telemetry.track_event(
+                "FeatureEvaluation",
+                "test_user",
+                {
+                    "microsoft.custom_event.name": "override_attempt",
+                    "CustomProperty": "custom_value",
+                },
+            )
+
+            mock_event_logger_info.assert_called_once()
+            assert mock_event_logger_info.call_args[0][0] == "FeatureEvaluation"
+            assert mock_event_logger_info.call_args.kwargs["extra"]["microsoft.custom_event.name"] == "FeatureEvaluation"
+            assert mock_event_logger_info.call_args.kwargs["extra"]["CustomProperty"] == "custom_value"
+            assert mock_event_logger_info.call_args.kwargs["extra"]["TargetingId"] == "test_user"
 
     def test_send_telemetry_appinsights_no_user(self):
         feature_flag = FeatureFlag.convert_from_json({"id": "TestFeature"})
@@ -67,18 +93,20 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_DISABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.azure_monitor_track_event") as mock_track_event:
+        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
             # This is called like this so we can override the track_event function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
             mock_track_event.assert_called_once()
             assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1]["FeatureName"] == "TestFeature"
-            assert mock_track_event.call_args[0][1]["Enabled"] == "False"
-            assert "TargetingId" not in mock_track_event.call_args[0][1]
-            assert mock_track_event.call_args[0][1]["Variant"] == "TestVariant"
-            assert mock_track_event.call_args[0][1]["VariantAssignmentReason"] == "DefaultWhenDisabled"
+            assert mock_track_event.call_args[0][1] == ""
+            event_properties = _event_properties(mock_track_event)
+            assert event_properties["FeatureName"] == "TestFeature"
+            assert event_properties["Enabled"] == "False"
+            assert "TargetingId" not in event_properties
+            assert event_properties["Variant"] == "TestVariant"
+            assert event_properties["VariantAssignmentReason"] == "DefaultWhenDisabled"
 
     def test_send_telemetry_appinsights_no_variant(self):
         feature_flag = FeatureFlag.convert_from_json({"id": "TestFeature"})
@@ -87,25 +115,26 @@ class TestSendTelemetryAppinsights:
         evaluation_event.enabled = True
         evaluation_event.user = "test_user"
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.azure_monitor_track_event") as mock_track_event:
+        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
             # This is called like this so we can override the track_event function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
             mock_track_event.assert_called_once()
             assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1]["FeatureName"] == "TestFeature"
-            assert mock_track_event.call_args[0][1]["Enabled"] == "True"
-            assert mock_track_event.call_args[0][1]["TargetingId"] == "test_user"
-            assert "Variant" not in mock_track_event.call_args[0][1]
-            assert "Reason" not in mock_track_event.call_args[0][1]
+            assert mock_track_event.call_args[0][1] == "test_user"
+            event_properties = _event_properties(mock_track_event)
+            assert event_properties["FeatureName"] == "TestFeature"
+            assert event_properties["Enabled"] == "True"
+            assert "Variant" not in event_properties
+            assert "Reason" not in event_properties
 
     def test_send_telemetry_appinsights_no_feature_flag(self):
         evaluation_event = EvaluationEvent(None)
         evaluation_event.enabled = True
         evaluation_event.user = "test_user"
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.azure_monitor_track_event") as mock_track_event:
+        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
             # This is called like this so we can override the track_event function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
@@ -130,18 +159,19 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_ENABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.azure_monitor_track_event") as mock_track_event:
+        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
             # This is called like this so we can override the track_event function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
             mock_track_event.assert_called_once()
             assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1]["FeatureName"] == "TestFeature"
-            assert mock_track_event.call_args[0][1]["Enabled"] == "True"
-            assert mock_track_event.call_args[0][1]["TargetingId"] == "test_user"
-            assert mock_track_event.call_args[0][1]["Variant"] == "big"
-            assert mock_track_event.call_args[0][1]["VariantAssignmentReason"] == "DefaultWhenEnabled"
+            assert mock_track_event.call_args[0][1] == "test_user"
+            event_properties = _event_properties(mock_track_event)
+            assert event_properties["FeatureName"] == "TestFeature"
+            assert event_properties["Enabled"] == "True"
+            assert event_properties["Variant"] == "big"
+            assert event_properties["VariantAssignmentReason"] == "DefaultWhenEnabled"
 
     def test_send_telemetry_appinsights_default_when_enabled_no_percentile(self):
         feature_flag = FeatureFlag.convert_from_json(
@@ -160,18 +190,19 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_ENABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.azure_monitor_track_event") as mock_track_event:
+        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
             # This is called like this so we can override the track_event function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
             mock_track_event.assert_called_once()
             assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1]["FeatureName"] == "TestFeature"
-            assert mock_track_event.call_args[0][1]["Enabled"] == "True"
-            assert mock_track_event.call_args[0][1]["TargetingId"] == "test_user"
-            assert mock_track_event.call_args[0][1]["Variant"] == "big"
-            assert mock_track_event.call_args[0][1]["VariantAssignmentReason"] == "DefaultWhenEnabled"
+            assert mock_track_event.call_args[0][1] == "test_user"
+            event_properties = _event_properties(mock_track_event)
+            assert event_properties["FeatureName"] == "TestFeature"
+            assert event_properties["Enabled"] == "True"
+            assert event_properties["Variant"] == "big"
+            assert event_properties["VariantAssignmentReason"] == "DefaultWhenEnabled"
 
     def test_send_telemetry_appinsights_allocation(self):
         feature_flag = FeatureFlag.convert_from_json(
@@ -190,20 +221,21 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.PERCENTILE
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.azure_monitor_track_event") as mock_track_event:
+        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
             # This is called like this so we can override the track_event function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
             mock_track_event.assert_called_once()
             assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1]["FeatureName"] == "TestFeature"
-            assert mock_track_event.call_args[0][1]["Enabled"] == "True"
-            assert mock_track_event.call_args[0][1]["TargetingId"] == "test_user"
-            assert mock_track_event.call_args[0][1]["Variant"] == "big"
-            assert mock_track_event.call_args[0][1]["VariantAssignmentReason"] == "Percentile"
-            assert mock_track_event.call_args[0][1]["VariantAssignmentPercentage"] == "25"
-            assert "DefaultWhenEnabled" not in mock_track_event.call_args[0][1]
+            assert mock_track_event.call_args[0][1] == "test_user"
+            event_properties = _event_properties(mock_track_event)
+            assert event_properties["FeatureName"] == "TestFeature"
+            assert event_properties["Enabled"] == "True"
+            assert event_properties["Variant"] == "big"
+            assert event_properties["VariantAssignmentReason"] == "Percentile"
+            assert event_properties["VariantAssignmentPercentage"] == "25"
+            assert "DefaultWhenEnabled" not in event_properties
 
     def test_targeting_span_processor(self, caplog):
         processor = TargetingSpanProcessor()

--- a/tests/test_send_telemetry_appinsights.py
+++ b/tests/test_send_telemetry_appinsights.py
@@ -66,7 +66,7 @@ class TestSendTelemetryAppinsights:
             patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_event_logger_info,
             patch("featuremanagement.azuremonitor._send_telemetry.HAS_OPENTELEMETRY_LOGGING", True),
         ):
-            featuremanagement.azuremonitor._send_telemetry.track_event(
+            featuremanagement.azuremonitor._send_telemetry.track_event(  # pylint: disable=protected-access
                 "FeatureEvaluation",
                 "test_user",
                 {

--- a/tests/test_send_telemetry_appinsights.py
+++ b/tests/test_send_telemetry_appinsights.py
@@ -57,17 +57,14 @@ class TestSendTelemetryAppinsights:
             assert event_properties["Enabled"] == "True"
             assert event_properties["Variant"] == "TestVariant"
             assert event_properties["ETag"] == "cmwBRcIAq1jUyKL3Kj8bvf9jtxBrFg-R-ayExStMC90"
-            assert (
-                event_properties["FeatureFlagReference"]
-                == "fake-store-uri/kv/.appconfig.featureflag/TestFeature"
-            )
+            assert event_properties["FeatureFlagReference"] == "fake-store-uri/kv/.appconfig.featureflag/TestFeature"
             assert event_properties["FeatureFlagId"] == "fake-feature-flag-id"
 
     def test_track_event_preserves_reserved_custom_event_name(self):
-        with patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"), patch(
-            "featuremanagement.azuremonitor._send_telemetry._event_logger.info"
-        ) as mock_event_logger_info, patch(
-            "featuremanagement.azuremonitor._send_telemetry.HAS_OPENTELEMETRY_LOGGING", True
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_event_logger_info,
+            patch("featuremanagement.azuremonitor._send_telemetry.HAS_OPENTELEMETRY_LOGGING", True),
         ):
             featuremanagement.azuremonitor._send_telemetry.track_event(
                 "FeatureEvaluation",
@@ -80,7 +77,9 @@ class TestSendTelemetryAppinsights:
 
             mock_event_logger_info.assert_called_once()
             assert mock_event_logger_info.call_args[0][0] == "FeatureEvaluation"
-            assert mock_event_logger_info.call_args.kwargs["extra"]["microsoft.custom_event.name"] == "FeatureEvaluation"
+            assert (
+                mock_event_logger_info.call_args.kwargs["extra"]["microsoft.custom_event.name"] == "FeatureEvaluation"
+            )
             assert mock_event_logger_info.call_args.kwargs["extra"]["CustomProperty"] == "custom_value"
             assert mock_event_logger_info.call_args.kwargs["extra"]["TargetingId"] == "test_user"
 

--- a/tests/test_send_telemetry_appinsights.py
+++ b/tests/test_send_telemetry_appinsights.py
@@ -13,8 +13,8 @@ import featuremanagement.azuremonitor._send_telemetry
 from featuremanagement.azuremonitor import TargetingSpanProcessor
 
 
-def _event_properties(mock_track_event):
-    return mock_track_event.call_args.kwargs["event_properties"]
+def _event_properties(mock_logger_info):
+    return mock_logger_info.call_args.kwargs["extra"]
 
 
 @pytest.mark.usefixtures("caplog")
@@ -44,15 +44,18 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_DISABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
-            # This is called like this so we can override the track_event function
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_logger_info,
+        ):
+            # This is called like this so we can override the _event_logger.info function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
-            mock_track_event.assert_called_once()
-            assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1] == "test_user"
-            event_properties = _event_properties(mock_track_event)
+            mock_logger_info.assert_called_once()
+            assert mock_logger_info.call_args[0][0] == "FeatureEvaluation"
+            event_properties = _event_properties(mock_logger_info)
+            assert event_properties["TargetingId"] == "test_user"
             assert event_properties["FeatureName"] == "TestFeature"
             assert event_properties["Enabled"] == "True"
             assert event_properties["Variant"] == "TestVariant"
@@ -91,15 +94,17 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_DISABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
-            # This is called like this so we can override the track_event function
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_logger_info,
+        ):
+            # This is called like this so we can override the _event_logger.info function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
-            mock_track_event.assert_called_once()
-            assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1] == ""
-            event_properties = _event_properties(mock_track_event)
+            mock_logger_info.assert_called_once()
+            assert mock_logger_info.call_args[0][0] == "FeatureEvaluation"
+            event_properties = _event_properties(mock_logger_info)
             assert event_properties["FeatureName"] == "TestFeature"
             assert event_properties["Enabled"] == "False"
             assert "TargetingId" not in event_properties
@@ -113,15 +118,17 @@ class TestSendTelemetryAppinsights:
         evaluation_event.enabled = True
         evaluation_event.user = "test_user"
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
-            # This is called like this so we can override the track_event function
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_logger_info,
+        ):
+            # This is called like this so we can override the _event_logger.info function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
-            mock_track_event.assert_called_once()
-            assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1] == "test_user"
-            event_properties = _event_properties(mock_track_event)
+            mock_logger_info.assert_called_once()
+            assert mock_logger_info.call_args[0][0] == "FeatureEvaluation"
+            event_properties = _event_properties(mock_logger_info)
             assert event_properties["FeatureName"] == "TestFeature"
             assert event_properties["Enabled"] == "True"
             assert "Variant" not in event_properties
@@ -132,12 +139,15 @@ class TestSendTelemetryAppinsights:
         evaluation_event.enabled = True
         evaluation_event.user = "test_user"
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
-            # This is called like this so we can override the track_event function
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_logger_info,
+        ):
+            # This is called like this so we can override the _event_logger.info function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
-            mock_track_event.assert_not_called()
+            mock_logger_info.assert_not_called()
 
     def test_send_telemetry_appinsights_default_when_enabled(self):
         feature_flag = FeatureFlag.convert_from_json(
@@ -157,15 +167,17 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_ENABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
-            # This is called like this so we can override the track_event function
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_logger_info,
+        ):
+            # This is called like this so we can override the _event_logger.info function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
-            mock_track_event.assert_called_once()
-            assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1] == "test_user"
-            event_properties = _event_properties(mock_track_event)
+            mock_logger_info.assert_called_once()
+            assert mock_logger_info.call_args[0][0] == "FeatureEvaluation"
+            event_properties = _event_properties(mock_logger_info)
             assert event_properties["FeatureName"] == "TestFeature"
             assert event_properties["Enabled"] == "True"
             assert event_properties["Variant"] == "big"
@@ -188,15 +200,17 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.DEFAULT_WHEN_ENABLED
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
-            # This is called like this so we can override the track_event function
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_logger_info,
+        ):
+            # This is called like this so we can override the _event_logger.info function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
-            mock_track_event.assert_called_once()
-            assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1] == "test_user"
-            event_properties = _event_properties(mock_track_event)
+            mock_logger_info.assert_called_once()
+            assert mock_logger_info.call_args[0][0] == "FeatureEvaluation"
+            event_properties = _event_properties(mock_logger_info)
             assert event_properties["FeatureName"] == "TestFeature"
             assert event_properties["Enabled"] == "True"
             assert event_properties["Variant"] == "big"
@@ -219,15 +233,17 @@ class TestSendTelemetryAppinsights:
         evaluation_event.variant = variant
         evaluation_event.reason = VariantAssignmentReason.PERCENTILE
 
-        with patch("featuremanagement.azuremonitor._send_telemetry.track_event") as mock_track_event:
-            # This is called like this so we can override the track_event function
+        with (
+            patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
+            patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_logger_info,
+        ):
+            # This is called like this so we can override the _event_logger.info function
             featuremanagement.azuremonitor._send_telemetry.publish_telemetry(  # pylint: disable=protected-access
                 evaluation_event
             )
-            mock_track_event.assert_called_once()
-            assert mock_track_event.call_args[0][0] == "FeatureEvaluation"
-            assert mock_track_event.call_args[0][1] == "test_user"
-            event_properties = _event_properties(mock_track_event)
+            mock_logger_info.assert_called_once()
+            assert mock_logger_info.call_args[0][0] == "FeatureEvaluation"
+            event_properties = _event_properties(mock_logger_info)
             assert event_properties["FeatureName"] == "TestFeature"
             assert event_properties["Enabled"] == "True"
             assert event_properties["Variant"] == "big"

--- a/tests/test_send_telemetry_appinsights.py
+++ b/tests/test_send_telemetry_appinsights.py
@@ -64,7 +64,6 @@ class TestSendTelemetryAppinsights:
         with (
             patch("featuremanagement.azuremonitor._send_telemetry._initialize_event_logger"),
             patch("featuremanagement.azuremonitor._send_telemetry._event_logger.info") as mock_event_logger_info,
-            patch("featuremanagement.azuremonitor._send_telemetry.HAS_OPENTELEMETRY_LOGGING", True),
         ):
             featuremanagement.azuremonitor._send_telemetry.track_event(  # pylint: disable=protected-access
                 "FeatureEvaluation",


### PR DESCRIPTION
**Overview**
This pull request modernizes the Azure Monitor telemetry integration by switching from the deprecated `azure-monitor-events-extension` to the OpenTelemetry logging handler. It updates the telemetry event sending logic, improves the handling of reserved log attributes, and refactors tests to match the new implementation. Dependency management and sample requirements are also updated for consistency.

**Telemetry integration updates:**

* Replaces usage of `azure-monitor-events-extension` with OpenTelemetry's `LoggingHandler` for sending telemetry events, introducing a dedicated logger (`_event_logger`) and initialization logic in `_send_telemetry.py`. This ensures telemetry events are sent in a more standard and extensible way.
* Updates the `track_event` and `publish_telemetry` functions to use the new logging-based approach, including logic to avoid conflicts with reserved log record attributes. [[1]](diffhunk://#diff-e599fecd01f487185b6b19104e39d7a20d310657896ddeee742af944b129945aL54-R93) [[2]](diffhunk://#diff-e599fecd01f487185b6b19104e39d7a20d310657896ddeee742af944b129945aL71-R102)
* Updates the `TargetingSpanProcessor` to check for OpenTelemetry logging support rather than the old extension.

**Dependency and configuration changes:**

* Updates the optional Azure Monitor dependency in `pyproject.toml` to require `opentelemetry-sdk` instead of `azure-monitor-events-extension`.
* Removes `azure-monitor-events-extension` from `samples/requirements.txt`.

**Testing improvements:**

* Refactors tests in `test_send_telemetry_appinsights.py` to patch the new `track_event` function instead of the old event extension, and adds a helper to extract event properties from mock calls. [[1]](diffhunk://#diff-47ef66c67d7a4d819410031b07b4557addbf59c7be9b8384fe18ce94b6171401R16-R19) [[2]](diffhunk://#diff-47ef66c67d7a4d819410031b07b4557addbf59c7be9b8384fe18ce94b6171401L43-R84) [[3]](diffhunk://#diff-47ef66c67d7a4d819410031b07b4557addbf59c7be9b8384fe18ce94b6171401L70-R108) [[4]](diffhunk://#diff-47ef66c67d7a4d819410031b07b4557addbf59c7be9b8384fe18ce94b6171401L90-R136) [[5]](diffhunk://#diff-47ef66c67d7a4d819410031b07b4557addbf59c7be9b8384fe18ce94b6171401L133-R173) [[6]](diffhunk://#diff-47ef66c67d7a4d819410031b07b4557addbf59c7be9b8384fe18ce94b6171401L163-R204) [[7]](diffhunk://#diff-47ef66c67d7a4d819410031b07b4557addbf59c7be9b8384fe18ce94b6171401L193-R237)
* Adds a new test to verify that reserved log record attributes (like `microsoft.custom_event.name`) are handled safely and not overwritten.

**Validation**
* Ran [quote-of-the-day-python sample](https://github.com/Azure-Samples/quote-of-the-day-python) locally. Changed the FeatureManagement-Python dependency to the local version using command:
```
pip install -e C:\Users\yuanqu\workplace\FeatureManagement-Python
```
Verified that *quota-of-the-day app* is still able to send telemetry to my testing app insights in the correct location.
<img width="759" height="692" alt="image" src="https://github.com/user-attachments/assets/4b052433-215e-49e4-b530-9c6f81710e8c" />
